### PR TITLE
Report workflow postreview fixes

### DIFF
--- a/.github/workflows/danger-comment.yml
+++ b/.github/workflows/danger-comment.yml
@@ -117,6 +117,6 @@ jobs:
             }
 
             // Fail if there are errors
-            if (report.errors && report.errors.length > 0) {
+            if (hasItems(report.errors)) {
               core.setFailed('Danger found errors');
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 0.2.2 (Next)
 
 * Your contribution here.
+* [#16](https://github.com/ruby-grape/danger/pull/16): Report workflow postreview fixes - [@numbata](https://github.com/numbata).
 * [#15](https://github.com/ruby-grape/danger/pull/15): Extract danger reporting infrastructure into reusable workflows and gem - [@numbata](https://github.com/numbata).
 
 ### 0.2.1 (2024/02/01)

--- a/Dangerfile
+++ b/Dangerfile
@@ -18,8 +18,7 @@ at_exit do
   reporter.export_json(
     ENV.fetch('DANGER_REPORT_PATH', nil),
     ENV.fetch('GITHUB_EVENT_PATH', nil)
-    )
-  break
+  )
 end
 
 # --------------------------------------------------------------------------------------------------------------------

--- a/Dangerfile
+++ b/Dangerfile
@@ -8,19 +8,18 @@ require 'English'
 # to get automatic reporting with their own custom checks.
 
 # Register at_exit hook to export report when Dangerfile finishes
+dangerfile_instance = self if defined?(Danger::Dangerfile) && is_a?(Danger::Dangerfile)
 at_exit do
   # Only skip if there's an actual exception (not SystemExit from danger calling exit)
   next if $ERROR_INFO && !$ERROR_INFO.is_a?(SystemExit)
+  next unless dangerfile_instance
 
-  # Find the Dangerfile instance and get its current status_report
-  ObjectSpace.each_object(Danger::Dangerfile) do |df|
-    reporter = RubyGrapeDanger::Reporter.new(df.status_report)
-    reporter.export_json(
-      ENV.fetch('DANGER_REPORT_PATH', nil),
-      ENV.fetch('GITHUB_EVENT_PATH', nil)
+  reporter = RubyGrapeDanger::Reporter.new(dangerfile_instance.status_report)
+  reporter.export_json(
+    ENV.fetch('DANGER_REPORT_PATH', nil),
+    ENV.fetch('GITHUB_EVENT_PATH', nil)
     )
-    break
-  end
+  break
 end
 
 # --------------------------------------------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ on:
 
 jobs:
   danger:
-    uses: ruby-grape/ruby-grape-danger/.github/workflows/danger-run.yml@main
+    uses: ruby-grape/danger/.github/workflows/danger-run.yml@main
 ```
 
 Create `.github/workflows/danger-comment.yml`:
@@ -75,7 +75,7 @@ on:
 
 jobs:
   comment:
-    uses: ruby-grape/ruby-grape-danger/.github/workflows/danger-comment.yml@main
+    uses: ruby-grape/danger/.github/workflows/danger-comment.yml@main
 ```
 
 ### Commit via a Pull Request
@@ -100,19 +100,12 @@ The workflows are separated into two stages:
    - Formats and posts results as a PR comment
    - Updates existing comment on subsequent runs
 
-### Benefits of Reusable Workflows
-
-✅ **DRY**: Define workflows once in `ruby-grape-danger`, reuse everywhere
-✅ **Consistent**: All Grape projects use the same reporting format and behavior
-✅ **Maintainable**: Fix a bug in the workflows once, all projects benefit automatically
-✅ **Scalable**: Add new checks to any project's Dangerfile without touching workflows
-
 ### How It Works
 
 When you reference the reusable workflows:
 
 ```yaml
-uses: ruby-grape/ruby-grape-danger/.github/workflows/danger-run.yml@main
+uses: ruby-grape/danger/.github/workflows/danger-run.yml@main
 ```
 
 GitHub Actions:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
   - [Commit via a Pull Request](#commit-via-a-pull-request)
 - [Reusable Workflows](#reusable-workflows)
   - [Architecture](#architecture)
-  - [Benefits of Reusable Workflows](#benefits-of-reusable-workflows)
   - [How It Works](#how-it-works)
   - [Examples](#examples)
 - [License](#license)

--- a/ruby-grape-danger.gemspec
+++ b/ruby-grape-danger.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_runtime_dependency 'danger', '~> 9'
-  s.add_runtime_dependency 'danger-changelog', '~> 0.7'
+  s.add_runtime_dependency 'danger-changelog', '~> 0.8'
   s.add_runtime_dependency 'danger-toc', '~> 0.2'
 end


### PR DESCRIPTION
This pull request makes several improvements to the Danger integration by simplifying the Dangerfile logic, updating workflow references for better maintainability, and clarifying the documentation. The most significant changes are grouped below.

**Dangerfile and workflow logic improvements:**

* Simplified the `at_exit` hook in the `Dangerfile` to directly reference the current Dangerfile instance instead of searching through all objects, making the export logic more robust and efficient.
* Updated the error check in `.github/workflows/danger-comment.yml` to use the `hasItems` utility for consistency and reliability.

**Documentation and workflow reference updates:**

* Changed all workflow references in the `README.md` from `ruby-grape/ruby-grape-danger` to `ruby-grape/danger`, reflecting the new reusable workflow location for easier updates and consistency across projects.
* Removed the "Benefits of Reusable Workflows" section from the `README.md` to streamline and clarify the documentation.